### PR TITLE
Tweak the interaction area and add tooltips

### DIFF
--- a/front/src/components/Table/index.vue
+++ b/front/src/components/Table/index.vue
@@ -240,7 +240,10 @@ export default {
 
           &:nth-child(1) {
             width: 5%;
-            text-indent: 0.5em;
+
+            > label {
+              margin: 0 auto;
+            }
           }
           &:nth-child(2) {
             width: 30%;

--- a/front/src/components/Table/index.vue
+++ b/front/src/components/Table/index.vue
@@ -40,25 +40,29 @@
               <Icon v-if="task.info.status === 1"
                 class="action-icon"
                 type="ios-pause"
+                :title="$t('tasks.pauseDownloads')"
                 @click="$emit('on-pause', task)"></Icon>
               <Icon v-else-if="task.info.status !== 4"
                 class="action-icon"
                 type="ios-play"
+                :title="$t('tasks.continueDownloading')"
                 @click="$emit('on-resume', task)"></Icon>
               <Icon type="ios-trash"
                 class="action-icon"
+                :title="$t('tasks.deleteTask')"
                 @click="$emit('on-delete', task)"></Icon>
               <Icon class="action-icon"
                 type="ios-folder"
+                :title="$t('tasks.revealInFolder')"
                 @click="$emit('on-open', task)"></Icon>
               <Poptip placement="right-end"
                 :title="$t('tasks.detail')"
                 transfer
                 width="400"
                 trigger="click">
-                <Icon type="ios-eye-outline"
-                  style="padding-left: 0.625rem;padding-top: 0.1rem;"
-                  class="action-icon"></Icon>
+                <Icon class="action-icon"
+                  :title="$t('tasks.detail')"
+                  type="ios-eye-outline"></Icon>
                 <div class="file-detail"
                   slot="content">
                   <p>
@@ -261,6 +265,19 @@ export default {
         .th {
           background-color: #f8f8f9;
           text-align: left;
+        }
+      }
+
+      .tds {
+        > .td:last-child {
+          .action-icon {
+            padding: 3px 5px;
+            margin-right: 5px;
+
+            &:last-child {
+              margin-right: 0;
+            }
+          }
         }
       }
 

--- a/front/src/i18n/en-US.js
+++ b/front/src/i18n/en-US.js
@@ -26,6 +26,7 @@ export default {
     pauseDownloads: 'Pause',
     deleteTask: 'Delete Task',
     deleteTaskTip: 'Delete both task and file',
+    revealInFolder: 'Reveal in download folder',
     method: 'Method',
     url: 'URL',
     fileName: 'Name',

--- a/front/src/i18n/zh-CN.js
+++ b/front/src/i18n/zh-CN.js
@@ -26,6 +26,7 @@ export default {
     pauseDownloads: '暂停下载',
     deleteTask: '删除任务',
     deleteTaskTip: '是否删除任务和文件？',
+    revealInFolder: '打开下载目录',
     method: '方法',
     url: '链接',
     fileName: '文件名',

--- a/front/src/i18n/zh-TW.js
+++ b/front/src/i18n/zh-TW.js
@@ -26,6 +26,7 @@ export default {
     pauseDownloads: '暫停下載',
     deleteTask: '刪除任務',
     deleteTaskTip: '是否刪除任務和檔案？',
+    revealInFolder: '打開下載目錄',
     method: '方法',
     url: '連結',
     fileName: '名稱',

--- a/front/src/views/Extension.vue
+++ b/front/src/views/Extension.vue
@@ -12,30 +12,46 @@
     <div class="proxy-switch-div">
       <b>{{ $t('extension.globalProxy') }}</b>
       <Switch v-model="proxySwitch"
-        @on-change="changeProxyMode"></Switch>
-      <Tooltip placement="bottom">
+        @on-change="changeProxyMode">
+      </Switch>
+
+      <Tooltip :content="$t('extension.proxyTip')"
+        theme="light">
         <Icon type="help-circled"
           @click="openUrl('https://github.com/proxyee-down-org/proxyee-down/wiki/%E5%AE%89%E8%A3%85%E6%89%A9%E5%B1%95')"
           class="action-icon tip-icon" />
-        <div slot="content">
-          <p>{{ $t('extension.proxyTip') }}</p>
-        </div>
       </Tooltip>
-      <Button type="info"
-        shape="circle"
-        icon="loop"
-        @click="loadExtensions"
-        :title="$t('tip.refresh')"></Button>
-      <Button type="info"
-        shape="circle"
-        icon="ios-copy"
-        @click="copyPac"
-        :title="$t('extension.copyPac')"></Button>
-      <Button type="info"
-        shape="circle"
-        icon="android-folder-open"
-        @click="installLocalExt"
-        :title="$t('extension.installLocalExt')"></Button>
+
+      <Tooltip class="icon-button"
+        :content="$t('tip.refresh')"
+        theme="light">
+        <Button type="info"
+          shape="circle"
+          icon="loop"
+          @click="loadExtensions">
+        </Button>
+      </Tooltip>
+
+      <Tooltip class="icon-button"
+        :content="$t('extension.copyPac')"
+        theme="light">
+        <Button type="info"
+          shape="circle"
+          icon="ios-copy"
+          @click="copyPac">
+        </Button>
+      </Tooltip>
+
+      <Tooltip class="icon-button"
+        :content="$t('extension.installLocalExt')"
+        theme="light">
+        <Button type="info"
+          shape="circle"
+          icon="android-folder-open"
+          @click="installLocalExt">
+        </Button>
+      </Tooltip>
+
     </div>
     <Tabs type="card"
       :animated="false"
@@ -474,7 +490,7 @@ export default {
 .proxy-switch-div b {
   padding-right: 10px;
 }
-.proxy-switch-div button {
+.proxy-switch-div .icon-button {
   margin-left: 25px;
 }
 .spin-icon-load {


### PR DESCRIPTION
1. 原下载交互栏图标太挤了，交互区域也太小，没有 tooltip，都调整一下，另外 i18n 也同步了。

1. 原勾选框显示有问题，一并修正。

1. 原扩展管理界面的几个按钮显没有 tooltip。


**附图:**

1. ![default](https://user-images.githubusercontent.com/383132/48472262-d8e8a680-e830-11e8-9186-e3b15acf4eaf.png)

1. ![default](https://user-images.githubusercontent.com/383132/48472126-7ee7e100-e830-11e8-9f92-69cfeea3634c.png)

1. ![default](https://user-images.githubusercontent.com/383132/48473366-41d11e00-e833-11e8-9fb9-4d7819caeff6.png)

